### PR TITLE
Fixes bug in unit tests that meant exceptions were being "hidden" from callables and uses unchecked instead of checked exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .flattened-pom.xml
 target
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>

--- a/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambda.java
+++ b/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambda.java
@@ -6,6 +6,7 @@ import java.net.InetAddress;
 import java.security.Permission;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static java.lang.Class.forName;
 import static java.lang.System.*;
@@ -522,6 +523,12 @@ public class SystemLambda {
 		return tapStream.textThatWasWritten();
 	}
 
+	public static Collection<String> tapSystemErrToCollection(
+			Statement statement
+	) throws Exception {
+		return toCollection(tapSystemOut(statement));
+	}
+
 	/**
 	 * Executes the statement and returns the text that was written to
 	 * {@code System.err} by the statement. New line characters are replaced
@@ -579,6 +586,12 @@ public class SystemLambda {
 			statement
 		);
 		return tapStream.textThatWasWritten();
+	}
+
+	public static Collection<String> tapSystemOutToCollection(
+			Statement statement
+	) throws Exception {
+		return toCollection(tapSystemOut(statement));
 	}
 
 	/**
@@ -805,6 +818,13 @@ public class SystemLambda {
 			AUTO_FLUSH,
 			DEFAULT_ENCODING
 		);
+	}
+
+	private static Collection<String> toCollection(
+			String value
+	) {
+		String[] lines = value.split(System.lineSeparator());
+		return Arrays.stream(lines).collect(Collectors.toList());
 	}
 
 	private static class DisallowWriteStream extends OutputStream {

--- a/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambda.java
+++ b/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambda.java
@@ -1111,7 +1111,6 @@ public class SystemLambda {
 		 * @param <T> the type of {@code callable}'s result
 		 * @param callable an arbitrary piece of code.
 		 * @return the return value of {@code callable}.
-		 * @throws Exception any exception thrown by the callable.
 		 * @since 1.1.0
 		 * @see #withEnvironmentVariable(String, String)
 		 * @see #and(String, String)
@@ -1119,11 +1118,13 @@ public class SystemLambda {
 		 */
 		public <T> T execute(
 			Callable<T> callable
-		) throws Exception {
+		) {
 			Map<String, String> originalVariables = new HashMap<>(getenv());
 			try {
 				setEnvironmentVariables();
 				return callable.call();
+			} catch (Exception e) {
+				throw new SystemLambdaExecutionException(e);
 			} finally {
 				restoreOriginalVariables(originalVariables);
 			}
@@ -1159,7 +1160,6 @@ public class SystemLambda {
 		 * environment variables map. It fails if your {@code SecurityManager} forbids
 		 * such modifications.
 		 * @param statement an arbitrary piece of code.
-		 * @throws Exception any exception thrown by the statement.
 		 * @since 1.0.0
 		 * @see #withEnvironmentVariable(String, String)
 		 * @see WithEnvironmentVariables#and(String, String)
@@ -1167,11 +1167,13 @@ public class SystemLambda {
 		 */
     	public void execute(
     		Statement statement
-		) throws Exception {
+		) {
     		Map<String, String> originalVariables = new HashMap<>(getenv());
     		try {
 				setEnvironmentVariables();
 				statement.execute();
+			} catch (Exception e) {
+    			throw new SystemLambdaExecutionException(e);
 			} finally {
 				restoreOriginalVariables(originalVariables);
 			}

--- a/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambdaExecutionException.java
+++ b/src/main/java/com/github/stefanbirkner/systemlambda/SystemLambdaExecutionException.java
@@ -1,0 +1,8 @@
+package com.github.stefanbirkner.systemlambda;
+
+public class SystemLambdaExecutionException extends RuntimeException {
+
+	public SystemLambdaExecutionException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/FailingCallableMock.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/FailingCallableMock.java
@@ -1,0 +1,14 @@
+package com.github.stefanbirkner.systemlambda;
+
+import java.util.concurrent.Callable;
+
+class FailingCallableMock implements Callable<String> {
+	boolean hasBeenEvaluated = false;
+	Exception exception = new Exception("failing callable mock exception");
+
+	@Override
+	public String call() throws Exception {
+		hasBeenEvaluated = true;
+		throw exception;
+	}
+}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/FailingStatementMock.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/FailingStatementMock.java
@@ -1,0 +1,12 @@
+package com.github.stefanbirkner.systemlambda;
+
+class FailingStatementMock implements Statement {
+	boolean hasBeenEvaluated = false;
+	Exception exception = new Exception("failing statement mock exception");
+
+	@Override
+	public void execute() throws Exception {
+		hasBeenEvaluated = true;
+		throw exception;
+	}
+}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/SystemLambdaExecutionExceptionTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/SystemLambdaExecutionExceptionTest.java
@@ -1,0 +1,17 @@
+package com.github.stefanbirkner.systemlambda;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SystemLambdaExecutionExceptionTest {
+
+	@Test
+	void shouldReturnCause() {
+		Throwable cause = new Exception("cause");
+
+		Throwable exception = new SystemLambdaExecutionException(cause);
+
+		assertThat(exception.getCause()).isEqualTo(cause);
+	}
+}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/TapSystemErrTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/TapSystemErrTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErr;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErrToCollection;
 import static java.lang.System.err;
+import static java.lang.System.out;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -24,6 +28,17 @@ class TapSystemErrTest {
 	}
 
 	@Test
+	void taps_text_that_is_written_to_System_err_by_statement_to_collection(
+	) throws Exception {
+		Collection<String> linesWrittenToSystemErr = tapSystemErrToCollection(
+				() -> { out.println("some text"); out.println("more text"); }
+		);
+
+		assertThat(linesWrittenToSystemErr)
+				.containsExactly("some text", "more text");
+	}
+
+	@Test
 	void tapped_text_is_empty_when_statement_does_not_write_to_System_err(
 	) throws Exception {
 		String textWrittenToSystemErr = tapSystemErr(
@@ -31,7 +46,7 @@ class TapSystemErrTest {
 		);
 
 		assertThat(textWrittenToSystemErr)
-			.isEqualTo("");
+			.isEmpty();
 	}
 
 	@Nested

--- a/src/test/java/com/github/stefanbirkner/systemlambda/TapSystemOutTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/TapSystemOutTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutToCollection;
 import static java.lang.System.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,6 +27,17 @@ class TapSystemOutTest {
 	}
 
 	@Test
+	void taps_text_that_is_written_to_System_out_by_statement_to_collection(
+	) throws Exception {
+		Collection<String> linesWrittenToSystemOut = tapSystemOutToCollection(
+				() -> { out.println("some text"); out.println("more text"); }
+		);
+
+		assertThat(linesWrittenToSystemOut)
+				.containsExactly("some text", "more text");
+	}
+
+	@Test
 	void tapped_text_is_empty_when_statement_does_not_write_to_System_out(
 	) throws Exception {
 		String textWrittenToSystemOut = tapSystemOut(
@@ -31,7 +45,7 @@ class TapSystemOutTest {
 		);
 
 		assertThat(textWrittenToSystemOut)
-			.isEqualTo("");
+			.isEmpty();
 	}
 
 	@Nested

--- a/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
@@ -249,13 +249,14 @@ class WithEnvironmentVariableTest {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
 
-			ignoreException(
+			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
 					.execute(() -> (Callable<String>) () -> {
 						throw new RuntimeException("dummy exception");
 					})
 			);
 
+			assertThat(error).hasMessage("dummy exception");
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 
@@ -264,13 +265,14 @@ class WithEnvironmentVariableTest {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
 
-			ignoreException(
+			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
 					.execute(() -> {
 						throw new RuntimeException("dummy exception"); }
 					)
 			);
 
+			assertThat(error).hasMessage("dummy exception");
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 	}
@@ -304,13 +306,14 @@ class WithEnvironmentVariableTest {
 		void after_callable_throws_exception() {
 			String originalValue = getenv("dummy name");
 
-			ignoreException(
+			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
 					.execute(() -> (Callable<String>) () -> {
 						throw new RuntimeException("dummy exception");
 					})
 			);
 
+			assertThat(error).hasMessage("dummy exception");
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 
@@ -318,7 +321,7 @@ class WithEnvironmentVariableTest {
 		void after_statement_throws_exception() {
 			String originalValue = getenv("dummy name");
 
-			ignoreException(
+			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
 					.execute(() -> {
 							throw new RuntimeException("dummy exception");
@@ -326,6 +329,7 @@ class WithEnvironmentVariableTest {
 					)
 			);
 
+			assertThat(error).hasMessage("dummy exception");
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 	}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static com.github.stefanbirkner.fishbowl.Fishbowl.ignoreException;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static java.lang.System.getenv;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -251,7 +250,7 @@ class WithEnvironmentVariableTest {
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute(() -> (Callable<String>) () -> {
+					.execute((Callable<String>) () -> {
 						throw new RuntimeException("dummy exception");
 					})
 			);
@@ -308,7 +307,7 @@ class WithEnvironmentVariableTest {
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute(() -> (Callable<String>) () -> {
+					.execute((Callable<String>) () -> {
 						throw new RuntimeException("dummy exception");
 					})
 			);

--- a/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 class WithEnvironmentVariableTest {
 	@Test
 	void callable_is_executed(
-	) throws Exception {
+	) {
 		CallableMock callable = new CallableMock();
 		withEnvironmentVariable("dummy name", "dummy value")
 			.execute(callable);
@@ -29,7 +29,7 @@ class WithEnvironmentVariableTest {
 
 	@Test
 	void return_value_of_callable_is_exposed(
-	) throws Exception {
+	) {
 		String value = withEnvironmentVariable("dummy name", "dummy value")
 			.execute(() -> "return value");
 
@@ -38,7 +38,7 @@ class WithEnvironmentVariableTest {
 
 	@Test
 	void statement_is_executed(
-	) throws Exception {
+	) {
 		StatementMock statementMock = new StatementMock();
 
 		withEnvironmentVariable("dummy name", "dummy value")
@@ -51,7 +51,7 @@ class WithEnvironmentVariableTest {
 	class environment_variable_that_is_set_to_some_value {
 		@Test
 		void is_available_in_the_callable(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("dummy name", "dummy value")
 				.execute(() -> {
 					assertThat(getenv("dummy name")).isEqualTo("dummy value");
@@ -61,7 +61,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_available_in_the_statement(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("dummy name", "dummy value")
 				.execute(() ->
 					assertThat(getenv("dummy name")).isEqualTo("dummy value")
@@ -70,7 +70,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_available_in_the_callable_from_environment_variables_map(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("dummy name", "dummy value")
 				.execute(() -> {
 					assertThat(getenv()).containsEntry("dummy name", "dummy value");
@@ -80,7 +80,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_available_in_the_statement_from_environment_variables_map(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("dummy name", "dummy value")
 				.execute(() ->
 					assertThat(getenv()).containsEntry("dummy name", "dummy value")
@@ -92,7 +92,7 @@ class WithEnvironmentVariableTest {
 	class multiple_environment_variable_that_are_set_to_some_value {
 		@Test
 		void are_available_in_the_callable(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("first", "first value")
 				.and("second", "second value")
 				.execute(() -> {
@@ -104,7 +104,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void are_available_in_the_statement(
-		) throws Exception {
+		) {
 			withEnvironmentVariable("first", "first value")
 				.and("second", "second value")
 				.execute(() -> {
@@ -118,7 +118,7 @@ class WithEnvironmentVariableTest {
 	class environment_variable_that_is_set_to_null {
 		@Test
 		void is_null_in_the_callable(
-		) throws Exception {
+		) {
 			//we need to set a value because it is null by default
 			withEnvironmentVariable("dummy name", randomValue())
 				.execute(() ->
@@ -132,7 +132,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_null_in_the_statement(
-		) throws Exception {
+		) {
 			//we need to set a value because it is null by default
 			withEnvironmentVariable("dummy name", randomValue())
 				.execute(() ->
@@ -143,7 +143,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_not_stored_in_the_environment_variables_map_in_the_callable(
-		) throws Exception {
+		) {
 			//we need to set a value because it is null by default
 			withEnvironmentVariable("dummy name", randomValue())
 				.execute(() ->
@@ -157,7 +157,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void is_not_stored_in_the_environment_variables_map_in_the_statement(
-		) throws Exception {
+		) {
 			//we need to set a value because it is null by default
 			withEnvironmentVariable("dummy name", randomValue())
 				.execute(() ->
@@ -202,7 +202,7 @@ class WithEnvironmentVariableTest {
 
 	@Test
 	void the_and_method_creates_a_new_object_so_that_EnvironmentVariables_object_can_be_reused(
-	) throws Exception {
+	) {
 		WithEnvironmentVariables baseSetting = withEnvironmentVariable("first", "first value");
 		baseSetting.and("second", "second value")
 			.execute(() -> {});
@@ -219,7 +219,7 @@ class WithEnvironmentVariableTest {
 	class environment_variables_map_contains_same_values_as_before {
 		@Test
 		void after_callable_is_executed(
-		) throws Exception {
+		) {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
 
@@ -231,7 +231,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void after_statement_is_executed(
-		) throws Exception {
+		) {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
 
@@ -253,7 +253,9 @@ class WithEnvironmentVariableTest {
 					.execute(failingCallable)
 			);
 
-			assertThat(error).isEqualTo(failingCallable.exception);
+			assertThat(error)
+					.isInstanceOf(SystemLambdaExecutionException.class)
+					.hasCause(failingCallable.exception);
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 
@@ -268,7 +270,9 @@ class WithEnvironmentVariableTest {
 					.execute(failingStatement)
 			);
 
-			assertThat(error).isEqualTo(failingStatement.exception);
+			assertThat(error)
+					.isInstanceOf(SystemLambdaExecutionException.class)
+					.hasCause(failingStatement.exception);
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 	}
@@ -277,7 +281,7 @@ class WithEnvironmentVariableTest {
 	class environment_variables_are_the_same_as_before {
 		@Test
 		void after_callable_is_executed(
-		) throws Exception {
+		) {
 			String originalValue = getenv("dummy name");
 
 			withEnvironmentVariable("dummy name", randomValue())
@@ -288,7 +292,7 @@ class WithEnvironmentVariableTest {
 
 		@Test
 		void after_statement_is_executed(
-		) throws Exception {
+		) {
 			String originalValue = getenv("dummy name");
 
 			withEnvironmentVariable("dummy name", randomValue())
@@ -308,7 +312,9 @@ class WithEnvironmentVariableTest {
 					.execute(failingCallable)
 			);
 
-			assertThat(error).isEqualTo(failingCallable.exception);
+			assertThat(error)
+					.isInstanceOf(SystemLambdaExecutionException.class)
+					.hasCause(failingCallable.exception);
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 
@@ -322,7 +328,9 @@ class WithEnvironmentVariableTest {
 					.execute(failingStatement)
 			);
 
-			assertThat(error).isEqualTo(failingStatement.exception);
+			assertThat(error)
+					.isInstanceOf(SystemLambdaExecutionException.class)
+					.hasCause(failingStatement.exception);
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 	}

--- a/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
+++ b/src/test/java/com/github/stefanbirkner/systemlambda/WithEnvironmentVariableTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static java.lang.System.getenv;
@@ -247,15 +246,14 @@ class WithEnvironmentVariableTest {
 		void after_callable_throws_exception() {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
+			FailingCallableMock failingCallable = new FailingCallableMock();
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute((Callable<String>) () -> {
-						throw new RuntimeException("dummy exception");
-					})
+					.execute(failingCallable)
 			);
 
-			assertThat(error).hasMessage("dummy exception");
+			assertThat(error).isEqualTo(failingCallable.exception);
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 
@@ -263,15 +261,14 @@ class WithEnvironmentVariableTest {
 		void after_statement_throws_exception() {
 			Map<String, String> originalEnvironmentVariables
 				= new HashMap<>(getenv());
+			FailingStatementMock failingStatement = new FailingStatementMock();
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute(() -> {
-						throw new RuntimeException("dummy exception"); }
-					)
+					.execute(failingStatement)
 			);
 
-			assertThat(error).hasMessage("dummy exception");
+			assertThat(error).isEqualTo(failingStatement.exception);
 			assertThat(getenv()).isEqualTo(originalEnvironmentVariables);
 		}
 	}
@@ -304,31 +301,28 @@ class WithEnvironmentVariableTest {
 		@Test
 		void after_callable_throws_exception() {
 			String originalValue = getenv("dummy name");
+			FailingCallableMock failingCallable = new FailingCallableMock();
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute((Callable<String>) () -> {
-						throw new RuntimeException("dummy exception");
-					})
+					.execute(failingCallable)
 			);
 
-			assertThat(error).hasMessage("dummy exception");
+			assertThat(error).isEqualTo(failingCallable.exception);
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 
 		@Test
 		void after_statement_throws_exception() {
 			String originalValue = getenv("dummy name");
+			FailingStatementMock failingStatement = new FailingStatementMock();
 
 			Throwable error = catchThrowable(
 				() -> withEnvironmentVariable("dummy name", randomValue())
-					.execute(() -> {
-							throw new RuntimeException("dummy exception");
-						}
-					)
+					.execute(failingStatement)
 			);
 
-			assertThat(error).hasMessage("dummy exception");
+			assertThat(error).isEqualTo(failingStatement.exception);
 			assertThat(getenv("dummy name")).isEqualTo(originalValue);
 		}
 	}


### PR DESCRIPTION
I was attempting to write a pull request to wrap the throwing of checked exceptions so that I don't have to add a ```throws Exception``` clause to the end of all my tests. I will also raise a PR for this shortly, however in doing so I came across a small bug in the unit tests for the scenario where a callable throws an exception.

The first commit in this PR shows how the bug can be recreated, I was expected the tests to receive an exception when I added the catchThrowable but they didn't. The second commit fixes the issue by removing the extra nesting levels for the lambda.

I also added an explicit version for the maven surefire plugin into the POM as I found when trying to run the tests this was failing for me since I didn't have the latest version.

Neither are big issues but since I came across them I thought I would share what I found.